### PR TITLE
make gulpfile.js more compiler-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This is a common, reusable Gulp file tailored towards front-end focused projects
 | Features          | NPM Modules                                              |
 | ----------------- |--------------------------------------------------------|
 | General           | [Util](https://www.npmjs.com/package/gulp-util), [Changed](https://www.npmjs.com/package/gulp-changed), [Run sequence](https://www.npmjs.com/package/run-sequence), [Del](https://www.npmjs.com/package/del) |
-| Sass `sass`       | [Libsass](https://www.npmjs.com/package/node-sass), [Autoprefixer](https://www.npmjs.com/package/gulp-autoprefixer), [CSS Nano](https://www.npmjs.com/package/gulp-cssnano), [Sourcemaps](https://www.npmjs.com/package/gulp-sourcemaps), [Combine media queries](https://www.npmjs.com/package/gulp-combine-mq), [Clip Empty Files](https://www.npmjs.com/package/gulp-clip-empty-files) |
-| JavaScript `js`   | [Uglify](https://www.npmjs.com/package/gulp-uglify) |
+| Sass `styles`       | [Libsass](https://www.npmjs.com/package/node-sass), [Autoprefixer](https://www.npmjs.com/package/gulp-autoprefixer), [CSS Nano](https://www.npmjs.com/package/gulp-cssnano), [Sourcemaps](https://www.npmjs.com/package/gulp-sourcemaps), [Combine media queries](https://www.npmjs.com/package/gulp-combine-mq), [Clip Empty Files](https://www.npmjs.com/package/gulp-clip-empty-files) |
+| JavaScript `script`   | [Uglify](https://www.npmjs.com/package/gulp-uglify) |
 | Images `img`      | [Imagemin](https://www.npmjs.com/package/gulp-imagemin) |
 
 ## Getting Started
@@ -35,12 +35,12 @@ npm i
 *This can be easily changed to suit your project.*
 ```
 +-- dist/
-|   +-- css
-|   +-- js
+|   +-- styles
+|   +-- script
 |   +-- img
 +-- src/
-|   +-- scss
-|   +-- js
+|   +-- styles
+|   +-- script
 |   +-- img
 +-- node_modules/
 +-- package.json/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,8 +7,10 @@
 var project = {
     src: 'src',
     dist: 'dist',
-    sass: 'scss',
-    js: 'js',
+    styles: 'styles',
+    stylesExtension: '.scss',
+    script: 'script',
+    scriptExtension: '.js',
     img: 'img'
 };
 
@@ -81,24 +83,24 @@ gulp.task( 'img', function() {
 
 
 // =============================================
-// JS `gulp js`
-// compiles js, Jshint, Minify if `--production`
+// SCRIPT `gulp script`
+// compiles script, Jshint, Minify if `--production`
 // =============================================
 
-gulp.task( 'js', function() {
-    return gulp.src( project.src + '/' + project.js + '/**/*.js' )
+gulp.task( 'script', function() {
+    return gulp.src( project.src + '/' + project.script + '/**/*' + project.scriptExtension )
         .pipe( environment.production ? $.uglify() : $.util.noop() )
-        .pipe( gulp.dest( project.dist + '/' + project.js ) );
+        .pipe( gulp.dest( project.dist + '/' + project.script ) );
 } );
 
 
 // =============================================
-// CSS `gulp css`
+// STYLES `gulp styles`
 // compiles scss to css, autoprefixer, combines media queries and minifies if `--production`
 // =============================================
 
-gulp.task( 'sass', function() {
-    return gulp.src( project.src + '/' + project.sass + '/**/*.scss' )
+gulp.task( 'styles', function() {
+    return gulp.src( project.src + '/' + project.styles + '/**/*' + project.stylesExtension )
         .pipe( $.clipEmptyFiles() )
         .pipe( environment.development ? $.sourcemaps.init() : $.util.noop() )
         .pipe( ! environment.production ? $.sass.sync().on( 'error', $.sass.logError ) : $.util.noop() )
@@ -107,12 +109,12 @@ gulp.task( 'sass', function() {
         .pipe( environment.development ? $.sourcemaps.write() : $.util.noop() )
         .pipe( environment.production ? $.combineMq() : $.util.noop() )
         .pipe( environment.production ? $.cssNano( option.cssNano ) : $.util.noop() )
-        .pipe( gulp.dest( project.dist + '/css' ) );
+        .pipe( gulp.dest( project.dist + '/' + project.styles ) );
 } );
 
 
 // =============================================
-// Clean `gulp clean
+// Clean `gulp` clean
 // destroys the build directory
 // =============================================
 
@@ -122,29 +124,29 @@ gulp.task( 'clean', function( cb ) {
 
 
 // =============================================
-// Build 'gulp build'
+// Build `gulp build`
 // builds all assets, also has `--production` option to build production ready assets
 // =============================================
 
 gulp.task( 'build', function( cb ) {
-    $.runSequence( 'clean', [ 'img', 'js', 'sass' ], cb );
+    $.runSequence( 'clean', [ 'img', 'scripts', 'styles' ], cb );
 } );
 
 
 // =============================================
-// Watch 'gulp watch'
+// Watch `gulp watch`
 // watches files and runs defined task on change
 // =============================================
 
 gulp.task( 'watch', function( cb ) {
     gulp.watch( project.src + '/' + project.img + '/**/*', [ 'img' ] );
-    gulp.watch( project.src + '/' + project.js + '/**/*.js', [ 'js' ] );
-    gulp.watch( project.src + '/' + project.sass + '/**/*.scss', [ 'sass' ] );
+    gulp.watch( project.src + '/' + project.script + '/**/*' + project.scriptExtension, [ 'script' ] );
+    gulp.watch( project.src + '/' + project.styles + '/**/*' + project.stylesExtension, [ 'styles' ] );
 } );
 
 
 // =============================================
-// Default 'gulp'
+// Default `gulp`
 // runs build task, Runs watch tasks
 // =============================================
 


### PR DESCRIPTION
rename 'sass' and 'js' to 'styles' and 'script' respectively, to allow better drop-in compiler replacement (e.g. cssnext, tsc)